### PR TITLE
Assume ordered mapping to avoid unnecessary sorting (breaks backwards compat.)

### DIFF
--- a/python/pcompress/record.py
+++ b/python/pcompress/record.py
@@ -57,8 +57,8 @@ class Record:
     def __next__(self):
         try:
             step = next(self.chain)
-            assignment = [step.assignment[i] for i in sorted(step.assignment.to_dict().keys())]
-            state = str(assignment) + "\n"
+            assignment = step.assignment.mapping.values()
+            state = str(list(assignment)) + "\n"
             self.child.stdin.write(state.encode())
             return step
 


### PR DESCRIPTION
GerryChain's `retworkx` branch is now fast enough to warrant profiling/optimizing `pcompress` (the Python part of it, that is). 

With this change, https://github.com/mggg/GerryChain/pull/381/files#diff-da8db0188ac13cf96790b0e942fbcf3fab038487158df62d9910e450c506adbdL32-R37, we can remove the sort operation in `pcompress` and rely on GerryChain to maintain this as an invariant. This PR **WILL** break backwards compatibility, so great care must be taken to ensure that newer versions of `pcompress` are not mixed with older versions of `GerryChain`.